### PR TITLE
Alter requirements: python-instagram to python-instagram-2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     license=str('BSD-3 License'),
     install_requires=[
         'django>=1.6',
-        'python-instagram'
+        'python-instagram-2'
     ],
     classifiers=[
         'Environment :: Web Environment',


### PR DESCRIPTION
The python-instagram package has not been updated and is in error.
I created a new (python-instagram-2) with bug fixes.