### PR TITLE
Update name for templatetags library

### DIFF
--- a/django_instagram/templates/django_instagram/recent_media_box.html
+++ b/django_instagram/templates/django_instagram/recent_media_box.html
@@ -1,4 +1,4 @@
-{% load staticfiles instagram_client %}
+{% load static instagram_client %}
 
 {% if recent_media %}
     <div class="django_instagram">

--- a/django_instagram/templates/django_instagram/recent_media_wall.html
+++ b/django_instagram/templates/django_instagram/recent_media_wall.html
@@ -1,4 +1,4 @@
-{% load staticfiles instagram_client %}
+{% load static instagram_client %}
 
 <link href="{% static 'django_instagram/css/wall.css' %}" rel="stylesheet" type="text/css"/>
 


### PR DESCRIPTION
This fixes compatibility with Django 3, by using static instead of
staticfiles.

Closes #28.